### PR TITLE
Fix code scanning alert no. 21: Database query built from user-controlled sources

### DIFF
--- a/server/controllers/user.controllers.js
+++ b/server/controllers/user.controllers.js
@@ -47,7 +47,7 @@ const handleUserLogin = async (req, res) => {
     }
 
     // Find user by email
-    const user = await userModel.findOne({ email });
+    const user = await userModel.findOne({ email: { $eq: email } });
     if (!user) {
       return res.status(400).json({ message: "User not found " });
     }


### PR DESCRIPTION
Fixes [https://github.com/abhishekraoas/MCA-Alumni-Network/security/code-scanning/21](https://github.com/abhishekraoas/MCA-Alumni-Network/security/code-scanning/21)

To fix the problem, we need to ensure that the `email` field is treated as a literal value in the MongoDB query. This can be achieved by using the `$eq` operator, which ensures that the value is interpreted as a literal and not as a query object. This change will prevent any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
