### PR TITLE
Fix code scanning alert no. 19: Database query built from user-controlled sources

### DIFF
--- a/server/controllers/user.controllers.js
+++ b/server/controllers/user.controllers.js
@@ -9,7 +9,7 @@ const handleUserSignUp = async (req, res) => {
     const { email, rollNo } = req.body;
 
     // Check if email already exists
-    const existingEmail = await userModel.findOne({ email });
+    const existingEmail = await userModel.findOne({ email: { $eq: email } });
     if (existingEmail) {
       return res.status(400).json({ message: "Email already exists" });
     }


### PR DESCRIPTION
Fixes [https://github.com/abhishekraoas/MCA-Alumni-Network/security/code-scanning/19](https://github.com/abhishekraoas/MCA-Alumni-Network/security/code-scanning/19)

To fix the problem, we need to ensure that the user-provided `email` value is treated as a literal value in the query. This can be achieved by using the `$eq` operator in the MongoDB query. This approach ensures that the `email` value is interpreted as a literal string and not as a query object, preventing potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
