### PR TITLE
Fix code scanning alert no. 20: Database query built from user-controlled sources

### DIFF
--- a/server/controllers/user.controllers.js
+++ b/server/controllers/user.controllers.js
@@ -15,7 +15,7 @@ const handleUserSignUp = async (req, res) => {
     }
 
     // Check if roll number already exists
-    const existingRollNo = await userModel.findOne({ rollNo });
+    const existingRollNo = await userModel.findOne({ rollNo: { $eq: rollNo } });
     if (existingRollNo) {
       return res.status(400).json({ message: "Roll number already exists" });
     }


### PR DESCRIPTION
Fixes [https://github.com/abhishekraoas/MCA-Alumni-Network/security/code-scanning/20](https://github.com/abhishekraoas/MCA-Alumni-Network/security/code-scanning/20)

To fix the problem, we need to ensure that the `rollNo` value is treated as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the query. This approach ensures that the user input is interpreted as a literal value, mitigating the risk of NoSQL injection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
